### PR TITLE
Path annotation can use primitive types

### DIFF
--- a/wasp/src/main/java/com/orhanobut/wasp/WaspRequest.java
+++ b/wasp/src/main/java/com/orhanobut/wasp/WaspRequest.java
@@ -124,7 +124,7 @@ final class WaspRequest {
                 Class<? extends Annotation> annotationType = annotation.annotationType();
                 if (annotationType == Path.class) {
                     String key = ((Path) annotation).value();
-                    addPathParam(key, (String) value);
+                    addPathParam(key, String.valueOf(value));
                     continue;
                 }
                 if (annotationType == Query.class) {


### PR DESCRIPTION
Path parameters can only accept String, but especially with rest's api i will access resources which have primitives type as id.
So i made less mistake if Wasp convert for me the given value, for exemple : 

@GET("/products/{id}")
    public void getProduct(@Path("id") int id, CallBack<Product> productCallBack);

I don't have to call my method this way : myService.getProduct(11,myCallback)
and not this way  myService.getProduct(String.valueOf(11),myCallback)

