### PR TITLE
creates WaspResponse and pass it to callBack in MockFactory.

### DIFF
--- a/wasp/src/main/java/com/orhanobut/wasp/MockFactory.java
+++ b/wasp/src/main/java/com/orhanobut/wasp/MockFactory.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +77,11 @@ class MockFactory implements NetworkStack {
             }
         }
 
-        callBack.onSuccess((T) responseString);
+        WaspResponse waspResponse = new WaspResponse(
+                waspRequest.getUrl(), statusCode, Collections.EMPTY_MAP, responseString, responseString.length(), 0
+        );
+
+        callBack.onSuccess((T) waspResponse);
     }
 
     /**

--- a/wasp/src/main/java/com/orhanobut/wasp/NetworkHandler.java
+++ b/wasp/src/main/java/com/orhanobut/wasp/NetworkHandler.java
@@ -87,7 +87,6 @@ final class NetworkHandler implements InvocationHandler {
 
     @Override
     public Object invoke(Object proxy, final Method method, Object[] args) throws Throwable {
-        Logger.d("Proxy method invoked");
         if (args.length == 0) {
             throw new IllegalArgumentException("Callback must be sent as param");
         }


### PR DESCRIPTION
After logging implementations, CallBack param in "NetworkStack.invokeRequest" waits WaspResponse.
We were passing String and that was giving ClassCastException.