### PR TITLE
Parser can now throw an exception so invalid son doesn't not crash application

### DIFF
--- a/wasp/src/main/java/com/orhanobut/wasp/NetworkHandler.java
+++ b/wasp/src/main/java/com/orhanobut/wasp/NetworkHandler.java
@@ -106,8 +106,12 @@ final class NetworkHandler implements InvocationHandler {
             @Override
             public void onSuccess(WaspResponse response) {
                 response.log(logLevel);
-                Object result = parser.fromJson(response.getBody(), methodInfo.getResponseObjectType());
-                new ResponseWrapper(callBack, result).submitResponse();
+                try {
+                    Object result = parser.fromJson(response.getBody(), methodInfo.getResponseObjectType());
+                    new ResponseWrapper(callBack, result).submitResponse();
+                } catch (Exception e) {
+                    callBack.onError(response.toWaspError(e.getMessage()));
+                }
             }
 
             @Override

--- a/wasp/src/main/java/com/orhanobut/wasp/WaspResponse.java
+++ b/wasp/src/main/java/com/orhanobut/wasp/WaspResponse.java
@@ -54,4 +54,8 @@ final class WaspResponse {
                 // Method is called but log level is not meant to log anything
         }
     }
+
+    public WaspError toWaspError(String errorMsg) {
+        return new WaspError(url, statusCode, headers, errorMsg, body.getBytes(), networkTime);
+    }
 }

--- a/wasp/src/main/java/com/orhanobut/wasp/parsers/GsonParser.java
+++ b/wasp/src/main/java/com/orhanobut/wasp/parsers/GsonParser.java
@@ -22,7 +22,7 @@ public class GsonParser implements Parser {
     }
 
     @Override
-    public <T> T fromJson(String content, Type type) {
+    public <T> T fromJson(String content, Type type) throws Exception{
         if (TextUtils.isEmpty(content)) {
             return null;
         }

--- a/wasp/src/main/java/com/orhanobut/wasp/parsers/Parser.java
+++ b/wasp/src/main/java/com/orhanobut/wasp/parsers/Parser.java
@@ -7,7 +7,7 @@ import java.lang.reflect.Type;
  */
 public interface Parser {
 
-    <T> T fromJson(String content, Type type);
+    <T> T fromJson(String content, Type type) throws Exception;
 
     String toJson(Object body);
 }


### PR DESCRIPTION
If my api gave me a 200 response code but the json is invalid it is was crashing the app