### PR TITLE
Fixes synchronous operations.

### DIFF
--- a/wasp/src/main/java/com/orhanobut/wasp/MockNetworkStack.java
+++ b/wasp/src/main/java/com/orhanobut/wasp/MockNetworkStack.java
@@ -34,7 +34,7 @@ class MockNetworkStack implements NetworkStack {
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T> void invokeRequest(RequestCreator waspRequest, final InternalCallback<T> waspCallback) {
+  public void invokeRequest(RequestCreator waspRequest, final InternalCallback<Response> waspCallback) {
     MockHolder mock = waspRequest.getMock();
     final int statusCode = mock.getStatusCode();
 
@@ -77,14 +77,14 @@ class MockNetworkStack implements NetworkStack {
           return;
         }
 
-        waspCallback.onSuccess((T) waspResponse);
+        waspCallback.onSuccess(waspResponse);
       }
     }, 1000);
 
   }
 
   @Override
-  public <T> T invokeRequest(RequestCreator requestCreator) {
+  public Object invokeRequest(RequestCreator requestCreator) {
     MockHolder mock = requestCreator.getMock();
     final int statusCode = mock.getStatusCode();
 
@@ -124,6 +124,6 @@ class MockNetworkStack implements NetworkStack {
       Logger.e(e.getMessage());
     }
 
-    return (T) waspResponse.getResponseObject();
+    return waspResponse.getResponseObject();
   }
 }

--- a/wasp/src/main/java/com/orhanobut/wasp/NetworkHandler.java
+++ b/wasp/src/main/java/com/orhanobut/wasp/NetworkHandler.java
@@ -163,7 +163,6 @@ final class NetworkHandler implements InvocationHandler {
     InternalCallback<Response> responseWaspCallback = new InternalCallback<Response>() {
       @Override
       public void onSuccess(Response response) {
-        response.log();
         if (waspRequest.isCancelled()) {
           Logger.i("Response not delivered because of cancelled request");
           return;

--- a/wasp/src/main/java/com/orhanobut/wasp/NetworkStack.java
+++ b/wasp/src/main/java/com/orhanobut/wasp/NetworkStack.java
@@ -5,7 +5,7 @@ package com.orhanobut.wasp;
  */
 interface NetworkStack {
 
-  <T> void invokeRequest(RequestCreator requestCreator, InternalCallback<T> waspCallback);
+  void invokeRequest(RequestCreator requestCreator, InternalCallback<Response> waspCallback);
 
-  <T> T invokeRequest(RequestCreator requestCreator) throws Exception;
+  Object invokeRequest(RequestCreator requestCreator) throws Exception;
 }


### PR DESCRIPTION
- T used in InternalCallback is wasp.Response class. Sync calls should return the given type of the request itself. I simply changed it to return Object. If you can suggest better alternative, that would be great.

- Future object is added to VolleyRequest. Either that or listener will be NonNull at a given time. RequestFuture's onResponse method must be called for blocking `future.get()` method to be finished.

Fixes #116 